### PR TITLE
Add PR hook to check base branch

### DIFF
--- a/.github/workflows/pr_base_branch_check.yml
+++ b/.github/workflows/pr_base_branch_check.yml
@@ -1,0 +1,20 @@
+name: PR Base Branch Check
+on: 
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: PR Base Branch Check
+      run: |
+        if [[ ${{ github.event.pull_request.base.ref }} == "main" ]]; then \
+          curl --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'content-type: application/json' \
+            --header 'Accept: application/vnd.github.v3+json' \
+            -d '{"body" : "I see you opened or edited a PR to merge into `main`. Please make sure that you are merging into the `stage` branch unless you really intend to merge into `main`. Thanks!"}' \
+            --fail
+        fi


### PR DESCRIPTION
Consulted the following links:
https://docs.github.com/en/rest/reference/pulls
https://docs.github.com/en/rest/reference/issues#create-an-issue-comment (because an issue == PR for Github)
https://frontside.com/blog/2020-05-26-github-actions-pull_request/

This PR hook will run whenever you open, reopen, or edit a PR. By editing, it means editing the PR title, the branch you want to merge into, or the PR description (this text). It won't trigger if you add comments to the PR, push additional commits, approve/deny changes, or add/remove reviewers.

