### PR TITLE
Only run action on pull requests to main

### DIFF
--- a/.github/workflows/pr_base_branch_check.yml
+++ b/.github/workflows/pr_base_branch_check.yml
@@ -2,6 +2,7 @@ name: PR Base Branch Check
 on: 
   pull_request:
     types: [opened, edited, reopened]
+    branches: main
 
 jobs:
   test:
@@ -9,12 +10,10 @@ jobs:
     steps:
     - name: PR Base Branch Check
       run: |
-        if [[ ${{ github.event.pull_request.base.ref }} == "main" ]]; then \
-          curl --request POST \
-            --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            --header 'content-type: application/json' \
-            --header 'Accept: application/vnd.github.v3+json' \
-            -d '{"body" : "I see you opened or edited a PR to merge into `main`. Please make sure that you are merging into the `stage` branch unless you really intend to merge into `main`. Thanks!"}' \
-            --fail
-        fi
+        curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --header 'Accept: application/vnd.github.v3+json' \
+          -d '{"body" : "I see you opened or edited a PR to merge into `main`. Please make sure that you are merging into the `stage` branch unless you really intend to merge into `main`. Thanks!"}' \
+          --fail


### PR DESCRIPTION
Currently the GitHub Action runs whenever a PR is opened, edited, or reopened, regardless of the base branch. This change will run the Action only when a PR is opened, edited, or reopened on the main branch, instead of checking if the branch is main within the Action.