### PR TITLE
Add yarn serve command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "serve": "yarn build && serve -s build"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Because the PWA needs to be served as static files to function, often times the command `yarn build` and `serve -s build` have to be run consecutively. This PR creates a new command in `package.json` so that these two commands can be run with `yarn serve`.