### PR TITLE
Move @testing-library dependencies to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@material-ui/styles": "^4.11.3",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
     "bootstrap": "^5.0.0-beta1",
     "clsx": "^1.1.1",
     "cra-template": "1.1.0",
@@ -70,6 +67,9 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.1.0",
+    "@testing-library/user-event": "^12.1.10",
     "react-test-renderer": "^17.0.2"
   }
 }


### PR DESCRIPTION
I noticed that the @testing-library dependencies were not in `devDependencies` so I moved them over there.