### PR TITLE
draw mode + default draw

### DIFF
--- a/src/Canvas/Canvas.jsx
+++ b/src/Canvas/Canvas.jsx
@@ -16,11 +16,11 @@ import {
 export default function Canvas() {
   const canvasContext = useContext(CanvasContext);
   const { electrodes, selected } = canvasContext.squares;
-  const { drawing, mouseDown } = canvasContext.state;
+  const { mouseDown } = canvasContext.state;
   const { allCombined } = canvasContext.combined;
   const combSelected = canvasContext.combined.selected;
   const {
-    setMouseDown, setDrawing, setElectrodes, setSelected, setComboLayout, setCombSelected,
+    setMouseDown, setElectrodes, setSelected, setComboLayout, setCombSelected,
   } = canvasContext;
 
   const actuationContext = useContext(ActuationContext);
@@ -41,9 +41,8 @@ export default function Canvas() {
   }, [setMouseDown]);
 
   const handleMouseUp = useCallback(() => {
-    setDrawing(false);
     setMouseDown(false);
-  }, [setDrawing, setMouseDown]);
+  }, [setMouseDown]);
 
   useEffect(() => {
     document.querySelector('.greenArea').addEventListener('mousedown', handleMouseDown);
@@ -55,7 +54,7 @@ export default function Canvas() {
   }, [handleMouseDown, handleMouseUp]);
 
   const handleMouseMove = useCallback((e) => { // creating new electrode
-    if (drawing && mouseDown) {
+    if (mode === 'DRAW' && mouseDown) {
       let elecAtXY = false;
 
       // electrode curr pos = init + deltas[idx]
@@ -66,7 +65,7 @@ export default function Canvas() {
       const y = Math.floor(e.offsetY / ELEC_SIZE) * ELEC_SIZE;
 
       for (let idx = 0; idx < deltas.length; idx += 1) {
-      // if an electrode already exists at this position
+        // if an electrode already exists at this position
         if (x === initPositions[idx][0] + deltas[idx][0]
           && y === initPositions[idx][1] + deltas[idx][1]) {
           elecAtXY = true;
@@ -89,7 +88,7 @@ export default function Canvas() {
         });
       }
     }
-  }, [drawing, electrodes, mouseDown, setElectrodes, allCombined]);
+  }, [mode, electrodes, mouseDown, setElectrodes, allCombined]);
 
   useEffect(() => { // mouseover eventlistener over whole canvas
     // when dragging over a space that doesn't have an existing electrode, create new one

--- a/src/Canvas/DraggableComb.jsx
+++ b/src/Canvas/DraggableComb.jsx
@@ -7,14 +7,18 @@ import useSelected from './useSelected';
 import useReset from './useReset';
 import './Canvas.css';
 import { CanvasContext } from '../Contexts/CanvasProvider';
+import { GeneralContext } from '../Contexts/GeneralProvider';
 import { ELEC_SIZE } from '../constants';
 
 function DraggableComb({ id, children }) {
+  const { mode } = useContext(GeneralContext);
+
   const context = useContext(CanvasContext);
   const { setDelta, setCombSelected, setDragging } = context;
   const {
-    delta, mouseDown, drawing, isDragging,
+    delta, mouseDown, isDragging,
   } = context.state;
+
   const { selected } = context.combined;
 
   const isSelected = selected && selected.indexOf(id) >= 0;
@@ -30,17 +34,17 @@ function DraggableComb({ id, children }) {
 
   const handleMouseDown = useCallback((e) => {
     if (e.which === 1) {
-      if (!isSelected && !drawing && !isDragging) {
+      if (!isSelected && mode !== 'DRAW' && !isDragging) {
         setCombSelected([...new Set([...selected, id])]);
       }
     }
-  }, [isDragging, setCombSelected, selected, id, drawing, isSelected]);
+  }, [isDragging, setCombSelected, selected, id, mode, isSelected]);
 
   const handleMouseOver = useCallback(() => {
-    if (mouseDown === true && !isSelected && !drawing && !isDragging) {
+    if (mouseDown === true && !isSelected && mode !== 'DRAW' && !isDragging) {
       setCombSelected([...new Set([...selected, id])]);
     }
-  }, [isDragging, drawing, id, isSelected, mouseDown, selected, setCombSelected]);
+  }, [isDragging, mode, id, isSelected, mouseDown, selected, setCombSelected]);
 
   useEffect(() => {
     if (dragItem && dragItem.current) {

--- a/src/Canvas/DraggableItem.jsx
+++ b/src/Canvas/DraggableItem.jsx
@@ -16,7 +16,7 @@ function DraggableItem({ id, children }) {
   const context = useContext(CanvasContext);
   const { setSelected, setDelta, setDragging } = context;
   const {
-    delta, mouseDown, drawing, isDragging,
+    delta, mouseDown, isDragging,
   } = context.state;
   const { electrodes } = context.squares;
   const elecSelected = context.squares.selected;
@@ -37,11 +37,11 @@ function DraggableItem({ id, children }) {
 
   const handleMouseDown = useCallback((e) => {
     if (e.which === 1) {
-      if (mode === 'CAN' && !isSelected && !drawing && !isDragging) {
+      if (mode === 'CAN' && !isSelected && mode !== 'DRAW' && !isDragging) {
         setSelected([...new Set([...elecSelected, id])]);
       }
     }
-  }, [isDragging, setSelected, elecSelected, id, drawing, isSelected]);
+  }, [isDragging, setSelected, elecSelected, id, mode, isSelected]);
 
   useEffect(() => {
     if (dragItem && dragItem.current) {
@@ -56,10 +56,10 @@ function DraggableItem({ id, children }) {
 
   // handles selection of existing electrodes
   const handleMouseOver = useCallback(() => {
-    if (mouseDown === true && mode === 'CAN' && !isSelected && !drawing && !isDragging) {
+    if (mouseDown === true && mode === 'CAN' && !isSelected && mode !== 'DRAW' && !isDragging) {
       setSelected([...new Set([...elecSelected, id])]);
     }
-  }, [isDragging, drawing, id, isSelected, mouseDown, elecSelected, setSelected]);
+  }, [isDragging, mode, id, isSelected, mouseDown, elecSelected, setSelected]);
 
   useEffect(() => {
     if (dragItem && dragItem.current) {

--- a/src/Contexts/CanvasProvider.jsx
+++ b/src/Contexts/CanvasProvider.jsx
@@ -107,9 +107,6 @@ const CanvasProvider = ({ children }) => {
         setMouseDown: (md) => {
           setState((stateBoi) => ({ ...stateBoi, mouseDown: md }));
         },
-        setDrawing: (draw) => {
-          setState((stateBoi) => ({ ...stateBoi, drawing: draw }));
-        },
       }}
     >
       {children}

--- a/src/Contexts/GeneralProvider.jsx
+++ b/src/Contexts/GeneralProvider.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 const GeneralContext = React.createContext();
 
 const GeneralProvider = ({ children }) => {
-  const [mode, setMode] = React.useState('CAN'); // either "PIN", "SEQ", or "CAN"
+  const [mode, setMode] = React.useState('DRAW'); // either "PIN", "SEQ", "CAN", or "DRAW"
   const bannerRef = React.useRef();
 
   return (

--- a/src/ControlPanel/ControlPanel.jsx
+++ b/src/ControlPanel/ControlPanel.jsx
@@ -102,8 +102,7 @@ export default function ControlPanel() {
   const canvasContext = useContext(CanvasContext);
   const actuationContext = useContext(ActuationContext);
   const { setMode } = useContext(GeneralContext);
-  const { drawing } = canvasContext.state;
-  const { setDrawing, setSelected, setCombSelected } = canvasContext;
+  const { setSelected, setCombSelected } = canvasContext;
   const { undo, redo } = actuationContext;
 
   const classes = useStyles();
@@ -112,9 +111,9 @@ export default function ControlPanel() {
   const [usbConnected, setUsbConnected] = useState(false);
 
   function toggleDraw() {
+    setMode('DRAW');
     setSelected([]);
     setCombSelected([]);
-    setDrawing(!drawing);
   }
 
   return (
@@ -155,7 +154,7 @@ export default function ControlPanel() {
                 <Highlight />
               </ListItem>
             </Tooltip>
-            <Tooltip title="Edit Canvas">
+            <Tooltip title="Select and Move Electrodes">
               <ListItem button onClick={() => setMode('CAN')}>
                 <GridOn />
               </ListItem>

--- a/src/ControlPanel/UploadButton.jsx
+++ b/src/ControlPanel/UploadButton.jsx
@@ -4,7 +4,7 @@ import { CanvasContext } from '../Contexts/CanvasProvider';
 export default function UploadButton() {
   const context = useContext(CanvasContext);
   const { electrodes } = context.state;
-  const { setDrawing, setElectrodes, setSelected } = context;
+  const { setElectrodes, setSelected } = context;
   async function openFilePicker() {
     try {
       const filehandle = await window.showOpenFilePicker();
@@ -37,7 +37,6 @@ export default function UploadButton() {
 
         setSelected([]);
         setElectrodes({ initPositions: newInitPositions, deltas: newDeltas });
-        setDrawing(false);
       }
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
### Summary 
- When hit Drawing button, turn drawing mode on and leave it on until hit one of the other "mode" buttons ("Map Pins", "Sequence Actuation", and "Move Electrodes")
  - This means that, once you hit the Drawing button, you can keep drawing until you hit another button to change the mode

- Change previous "Edit Canvas" button's tooltip to "Move Electrodes"

This closes #50