### PR TITLE
mouseup listener on whole page

### DIFF
--- a/src/Canvas/Canvas.jsx
+++ b/src/Canvas/Canvas.jsx
@@ -46,10 +46,10 @@ export default function Canvas() {
 
   useEffect(() => {
     document.querySelector('.greenArea').addEventListener('mousedown', handleMouseDown);
-    document.querySelector('.greenArea').addEventListener('mouseup', handleMouseUp);
+    document.addEventListener('mouseup', handleMouseUp);
     return () => {
       document.querySelector('.greenArea').removeEventListener('mousedown', handleMouseDown);
-      document.querySelector('.greenArea').removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('mouseup', handleMouseUp);
     };
   }, [handleMouseDown, handleMouseUp]);
 
@@ -375,7 +375,7 @@ export default function Canvas() {
       }
     }
     setFinalCombines(paths);
-  }, [allCombined, setComboLayout]);
+  }, [allCombined]);
 
   /* ########################### COMBINE STUFF END ########################### */
 

--- a/src/Canvas/useSelected.js
+++ b/src/Canvas/useSelected.js
@@ -140,7 +140,6 @@ export default function useSelected(callback, savingChanges) {
         // don't want to setElectrodes here because
         // might have combined being dragged out of bounds in next for loop
         // in which case we wouldn't want to change our electrodes' current positions
-        setSelected([]);
       }
 
       // handle dragged combined
@@ -168,12 +167,13 @@ export default function useSelected(callback, savingChanges) {
           }
           combines = allCombined.filter((x) => x[2] !== layVal).concat(selectedCombs);
         }
-        setCombSelected([]);
         setComboLayout(combines);
+        setCombSelected([]);
       }
 
       if (elecSelected.length > 0) {
         setElectrodes({ initPositions: electrodes.initPositions, deltas: copy });
+        setSelected([]);
       }
       setDelta(null);
 


### PR DESCRIPTION
### Summary
Previously, we had the problem where, after moving an electrode off the canvas on the y-axis, we selected electrodes by simply hovering over them (sans a left click). 

Changed the event listener for the `mouseup` event to be attached to the whole `document`. Previously, the event listener had been on only the green area of the canvas, so when we let go the electrode off the green area, the event listener never caught that event.

Additionally, this bug didn't always show up in my testing sessions but it'd involve the combined electrode being dragged off the bottom of the canvas. The electrodes being dragged off the canvas would go back to their original positions as expected. But the parts of the combined electrode that didn't go over the canvas would just...remain. I also fixed that by getting rid of an unnecessary dependency in the `render combines` useEffect section of Canvas.jsx.

This closes #64 