### PR TITLE
GitHub Cypress Action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,18 @@
+name: Cypress e2e tests
+on:
+  pull_request:
+    branches: stage
+
+jobs:
+  cypress:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: cypress
+        uses: cypress-io/github-action@v2
+        with:
+          start: yarn start
+          wait-on: 'http://localhost:3000'
+          config-file: cypress.json


### PR DESCRIPTION
As I mentioned [here](https://github.com/leofuturer/EWOD-GUI2.0/pull/79#issuecomment-826157632), I implemented basic Cypress e2e testing in GitHub Actions. You can check out one of the runs [here](https://github.com/leofuturer/EWOD-GUI2.0/actions/runs/787181407).