### PR TITLE
click/drag/new mode to unselect

### DIFF
--- a/src/Canvas/DraggableComb.jsx
+++ b/src/Canvas/DraggableComb.jsx
@@ -32,17 +32,42 @@ function DraggableComb({ id, children }) {
 
   const dragItem = useRef(null);
 
+  const [localMD, setLocalMD] = useState(false);
+
   const handleMouseDown = useCallback((e) => {
     if (e.which === 1) {
-      if (!isSelected && mode !== 'DRAW' && !isDragging) {
-        setCombSelected([...new Set([...selected, id])]);
+      if (mode !== 'DRAW' && !isDragging) {
+        if (mode === 'SEQ') {
+          console.log(`Clicked on C${id}`);
+        } else if (isSelected) {
+          setLocalMD(true);
+        } else {
+          setCombSelected([...new Set([...selected, id])]);
+        }
+      }
+    }
+  }, [isDragging, setCombSelected, selected, id, mode, isSelected]);
+
+  const handleMouseUp = useCallback(() => {
+    if (mode !== 'DRAW' && isSelected && !isDragging && localMD) {
+      if (mode === 'SEQ') {
+        console.log(`Clicked on C${id}`);
+      } else {
+        setCombSelected(selected.filter((x) => x !== id));
+        setLocalMD(false);
       }
     }
   }, [isDragging, setCombSelected, selected, id, mode, isSelected]);
 
   const handleMouseOver = useCallback(() => {
-    if (mouseDown === true && !isSelected && mode !== 'DRAW' && !isDragging) {
-      setCombSelected([...new Set([...selected, id])]);
+    if (mouseDown === true && mode !== 'DRAW' && !isDragging) {
+      if (mode === 'SEQ') {
+        console.log(`Clicked on C${id}`);
+      } else if (isSelected) {
+        setCombSelected(selected.filter((x) => x !== id));
+      } else {
+        setCombSelected([...new Set([...selected, id])]);
+      }
     }
   }, [isDragging, mode, id, isSelected, mouseDown, selected, setCombSelected]);
 
@@ -51,13 +76,15 @@ function DraggableComb({ id, children }) {
       const item = dragItem.current;
       item.addEventListener('mousedown', handleMouseDown);
       item.addEventListener('mouseover', handleMouseOver);
+      item.addEventListener('mouseup', handleMouseUp);
       return () => {
         item.removeEventListener('mousedown', handleMouseDown);
         item.removeEventListener('mouseover', handleMouseOver);
+        item.removeEventListener('mouseup', handleMouseUp);
       };
     }
     return undefined;
-  }, [handleMouseDown, handleMouseOver]);
+  }, [handleMouseDown, handleMouseOver, handleMouseUp]);
 
   const [savingChanges, setSaveChanges] = useState(false);
 

--- a/src/Canvas/DraggableItem.jsx
+++ b/src/Canvas/DraggableItem.jsx
@@ -35,42 +35,51 @@ function DraggableItem({ id, children }) {
 
   const dragItem = useRef(null);
 
+  const [localMD, setLocalMD] = useState(false);
+
   const handleMouseDown = useCallback((e) => {
     if (e.which === 1) {
-      if (mode === 'CAN' && !isSelected && mode !== 'DRAW' && !isDragging) {
-        setSelected([...new Set([...elecSelected, id])]);
+      if (mode !== 'DRAW' && !isDragging) {
+        if (isSelected) {
+          setLocalMD(true);
+        } else {
+          setSelected([...new Set([...elecSelected, id])]);
+        }
       }
     }
   }, [isDragging, setSelected, elecSelected, id, mode, isSelected]);
 
-  useEffect(() => {
-    if (dragItem && dragItem.current) {
-      const item = dragItem.current;
-      item.addEventListener('mousedown', handleMouseDown);
-      return () => {
-        item.removeEventListener('mousedown', handleMouseDown);
-      };
+  const handleMouseUp = useCallback(() => {
+    if (mode !== 'DRAW' && isSelected && !isDragging && localMD) {
+      setSelected(elecSelected.filter((x) => x !== id));
+      setLocalMD(false);
     }
-    return undefined;
-  }, [handleMouseDown]);
+  }, [isDragging, setSelected, elecSelected, id, mode, isSelected]);
 
-  // handles selection of existing electrodes
   const handleMouseOver = useCallback(() => {
-    if (mouseDown === true && mode === 'CAN' && !isSelected && mode !== 'DRAW' && !isDragging) {
-      setSelected([...new Set([...elecSelected, id])]);
+    if (mouseDown === true && mode !== 'DRAW' && !isDragging) {
+      if (isSelected) {
+        setSelected(elecSelected.filter((x) => x !== id));
+      } else {
+        setSelected([...new Set([...elecSelected, id])]);
+      }
     }
   }, [isDragging, mode, id, isSelected, mouseDown, elecSelected, setSelected]);
 
   useEffect(() => {
     if (dragItem && dragItem.current) {
       const item = dragItem.current;
+      item.addEventListener('mousedown', handleMouseDown);
       item.addEventListener('mouseover', handleMouseOver);
+      item.addEventListener('mouseup', handleMouseUp);
       return () => {
+        item.removeEventListener('mousedown', handleMouseDown);
         item.removeEventListener('mouseover', handleMouseOver);
+        item.removeEventListener('mouseup', handleMouseUp);
       };
     }
     return undefined;
-  }, [handleMouseOver]);
+  }, [handleMouseDown, handleMouseOver, handleMouseUp]);
 
   const [savingChanges, setSaveChanges] = useState(false);
 

--- a/src/ControlPanel/ControlPanel.jsx
+++ b/src/ControlPanel/ControlPanel.jsx
@@ -110,8 +110,8 @@ export default function ControlPanel() {
   const [usbPanelOpen, setUsbPanelOpen] = useState(false);
   const [usbConnected, setUsbConnected] = useState(false);
 
-  function toggleDraw() {
-    setMode('DRAW');
+  function setNewMode(newMode) {
+    setMode(newMode);
     setSelected([]);
     setCombSelected([]);
   }
@@ -131,7 +131,7 @@ export default function ControlPanel() {
         <Toolbar style={{ marginLeft: 40 }}>
           <List style={{ display: 'flex', flexDirection: 'row' }}>
             <Tooltip title="Draw">
-              <ListItem button onClick={toggleDraw} data-testid="draw-button">
+              <ListItem button onClick={() => setNewMode('DRAW')} data-testid="draw-button">
                 <Create />
               </ListItem>
             </Tooltip>
@@ -145,17 +145,17 @@ export default function ControlPanel() {
             <DownloadButton />
 
             <Tooltip title="Map Pins">
-              <ListItem button onClick={() => setMode('PIN')}>
+              <ListItem button onClick={() => setNewMode('PIN')}>
                 <FormatListNumberedOutlined />
               </ListItem>
             </Tooltip>
             <Tooltip title="Sequence Actuation">
-              <ListItem button onClick={() => setMode('SEQ')}>
+              <ListItem button onClick={() => setNewMode('SEQ')}>
                 <Highlight />
               </ListItem>
             </Tooltip>
             <Tooltip title="Select and Move Electrodes" data-testid="CAN">
-              <ListItem button onClick={() => setMode('CAN')}>
+              <ListItem button onClick={() => setNewMode('CAN')}>
                 <GridOn />
               </ListItem>
             </Tooltip>


### PR DESCRIPTION
### Description
Apologies for smushing two "unselect" functionalities into one PR. 
1. Enable user to unselect electrodes by dragging over or clicking them.
2. Unselect electrodes when switch modes (e.g., 'PIN', 'DRAW', etc.).
3. Did some cleaning up in the Draggable components (e.g. smushed two `useEffects` together, got rid of some React hook imports since only used them once).

This closes #41 