### PR TITLE
change focus to newly create sequence during insertion/pasting

### DIFF
--- a/src/Contexts/ActuationProvider.jsx
+++ b/src/Contexts/ActuationProvider.jsx
@@ -151,6 +151,7 @@ const ActuationProvider = ({ children }) => {
           setActuation((stateBoi) => ({
             ...stateBoi,
             pinActuate: newList,
+            currentStep: obj.id,
             simpleNum: actuation.simpleNum + 1,
           }));
         },


### PR DESCRIPTION
**What**: Let focus move to newly create sequence when insert/paste one.
**Why**: Better user experience. People are more likely to work on the new sequence block.
**How**: Simply change the currentStep in Actuation Context.

This resolves #86 