### PR TITLE
Fix USB connections to new EWOD devices

### DIFF
--- a/src/USBCommunication/USBCommunication.js
+++ b/src/USBCommunication/USBCommunication.js
@@ -22,18 +22,14 @@ function handleData(data, onRecvData) {
   onRecvData(voltage, current);
 }
 
-// connect new device give chrome permission to access device
-async function connectNewDevice() {
-  await navigator.hid.requestDevice({ filters });
-}
-
 // get device checks if there are any currently connected devices
 // and if not, will open pop up for new devices.
 async function getDevices(onRecvData) {
   let devices = await navigator.hid.getDevices();
 
   if (devices.length === 0) {
-    await connectNewDevice();
+    // requestDevice will open a pop up for the user to give permission for
+    await navigator.hid.requestDevice({ filters });
     devices = await navigator.hid.getDevices();
   }
 


### PR DESCRIPTION
Hey @Firius0408 @leofuturer,

I made a really tiny change to the USBCommunication.js file. I don't know if you remember from a couple of meetings back, there used to be a pop up when connecting to new devices. 

I took it out bc I can connect without it. But it turns out that pop up is required for new devices. So this PR just adds that back in. (It will pop up if no old devices is showing up).

![IMG-3919](https://user-images.githubusercontent.com/24722618/117557570-ef9a9d80-b028-11eb-9380-8eaf4bcf4728.jpg)
