### PR TITLE
pin text

### DIFF
--- a/src/Canvas/DraggableComb.jsx
+++ b/src/Canvas/DraggableComb.jsx
@@ -141,7 +141,7 @@ function DraggableComb({ id, children }) {
     >
       <g ref={dragItem}>
         <g style={transform}>
-          <g className={`${isSelected ? 'selected' : ''}`}>
+          <g className={`${mode === 'CAN' && isSelected ? 'selected' : ''}`}>
             {children}
           </g>
         </g>

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,6 @@ export const CANVAS_WIDTH = 26; // electrodes
 export const CANVAS_HEIGHT = 12; // electrodes
 export const CANVAS_TRUE_WIDTH = CANVAS_WIDTH * ELEC_SIZE;
 export const CANVAS_TRUE_HEIGHT = CANVAS_HEIGHT * ELEC_SIZE;
-export const MAX_NUM_COMBINES = (CANVAS_WIDTH * CANVAS_HEIGHT) / 2;
 
 export const SCROLL_HEIGHT = 35.8;
 export const CANVAS_REAL_HEIGHT = 100 - SCROLL_HEIGHT - 10;


### PR DESCRIPTION
### Description
Shows pin numbers associated with each electrode in PIN mode. 
- in the rightmost and topmost square in combined electrodes

While figuring out how to show pin number in only rightmost and topmost square of combined electrodes, changed how combined electrodes rendered. Now(?) that it doesn't matter what order combined electrodes are rendered in, can just use an Object that maps from combined electrode's unique ID to `[path, x, y]`, where x and y are the coordinates for the rightmost and topmost square of that electrode.

Considering whether I should move all styling electrode stylings into the DraggableItem and DraggableComb subcomponents since this file is so huge. Also I'd left some styling in DraggableComb in a long ago commit because I'm insane.

Aware that:
- prior mapping to electrodes exist even after clearing canvas
- no real method to delete pin mapping after it's been mapped once (can replace one pin for another on one electrode but can't actually erase mapping)
Will resolve in future PRs.

This closes #110 