### PR TITLE
Disable step forward/backward and left click on sequence while playing

### DIFF
--- a/src/Actuation/Scroll.jsx
+++ b/src/Actuation/Scroll.jsx
@@ -359,7 +359,7 @@ export default function Scroll() {
             <Pause fontSize="small" style={{ color: '#A06933' }} />
           </IconButton>
           <IconButton onClick={() => {
-            if (index !== 0) {
+            if (pause && index !== 0) {
               setCurrentStep(fullseq[index - 1]);
               setIndex(index - 1);
             }
@@ -376,7 +376,7 @@ export default function Scroll() {
             <PlayArrow fontSize="small" style={{ color: '#A06933' }} />
           </IconButton>
           <IconButton onClick={() => {
-            if (index !== fullseq.length - 1) {
+            if (pause && index !== fullseq.length - 1) {
               setCurrentStep(fullseq[index + 1]);
               setIndex(index + 1);
             }
@@ -463,12 +463,16 @@ export default function Scroll() {
                     variant="outlined"
                     style={{ backgroundColor: currentStep === key ? '#D4A373' : '#FEFAE0' }}
                     onClick={() => {
-                      setCurrentStep(key);
+                      if (pause) {
+                        setCurrentStep(key);
+                      }
                     }}
                     onContextMenu={(event) => {
                       if (pause) {
                         setCurrentStep(key);
                         handleClick(event);
+                      } else {
+                        bannerRef.current.getAlert('error', 'Please stop playing before editing!');
                       }
                     }}
                     key={key}


### PR DESCRIPTION
**Description**: As Leo suggested, now the user cannot left click to select the sequence block or step in/out during playing. Moreover, any attempts to modify the timeline would raise an error as a banner.

This resolves #117 