### PR TITLE
move setMap from draggables to pins

### DIFF
--- a/src/Canvas/Canvas.jsx
+++ b/src/Canvas/Canvas.jsx
@@ -27,7 +27,7 @@ export default function Canvas() {
   const { actuatePin, pushHistory } = actuationContext;
 
   const {
-    mode, currPin, pinToElec, elecToPin,
+    mode, currElec, elecToPin,
   } = useContext(GeneralContext);
 
   // sets mousedown status for selecting existing electrodes
@@ -204,7 +204,7 @@ export default function Canvas() {
                             ${mode === 'SEQ' && pinActuate.has(currentStep)
                             && Object.prototype.hasOwnProperty.call(elecToPin, `S${ind}`) && pinActuate.get(currentStep).content.has(elecToPin[`S${ind}`]) ? 'toSeq' : ''}
                             ${mode === 'CAN' && selected.includes(ind) ? 'selected' : ''}
-                            ${mode === 'PIN' && pinToElec[currPin] === `S${ind}` ? 'toPin' : ''}`}
+                            ${mode === 'PIN' && currElec === `S${ind}` ? 'toPin' : ''}`}
               onClick={() => {
                 if (mode === 'SEQ') {
                   if (Object.prototype.hasOwnProperty.call(elecToPin, `S${ind}`)) {
@@ -238,7 +238,7 @@ export default function Canvas() {
               className={`electrode
                             ${mode === 'SEQ' && pinActuate.has(currentStep)
                             && Object.prototype.hasOwnProperty.call(elecToPin, `C${comb[0]}`) && pinActuate.get(currentStep).content.has(elecToPin[`C${comb[0]}`]) ? 'toSeq' : ''}
-                            ${mode === 'PIN' && pinToElec[currPin] === `C${comb[0]}` ? 'toPin' : ''}`}
+                            ${mode === 'PIN' && currElec === `C${comb[0]}` ? 'toPin' : ''}`}
               data-testid="combined"
               onClick={() => {
                 if (mode === 'SEQ') {

--- a/src/Canvas/DraggableComb.jsx
+++ b/src/Canvas/DraggableComb.jsx
@@ -12,7 +12,7 @@ import { ELEC_SIZE } from '../constants';
 
 function DraggableComb({ id, children }) {
   const {
-    mode, currPin, pinToElec, setPinToElec, elecToPin, setElecToPin,
+    mode, setCurrElec,
   } = useContext(GeneralContext);
 
   const context = useContext(CanvasContext);
@@ -38,24 +38,8 @@ function DraggableComb({ id, children }) {
 
   const handleMouseDown = useCallback((e) => {
     if (e.which === 1) {
-      if (mode === 'PIN' && currPin) {
-        const elec = `C${id}`;
-        if (Object.prototype.hasOwnProperty.call(pinToElec, currPin)) {
-          delete elecToPin[pinToElec[currPin]];
-        }
-        if (Object.prototype.hasOwnProperty.call(elecToPin, elec)) {
-          delete pinToElec[elecToPin[elec]];
-        }
-        setPinToElec((curr) => {
-          const newObj = { ...curr };
-          newObj[currPin] = elec;
-          return newObj;
-        });
-        setElecToPin((curr) => {
-          const newObj = { ...curr };
-          newObj[elec] = currPin;
-          return newObj;
-        });
+      if (mode === 'PIN') {
+        setCurrElec(`C${id}`);
       } else if (mode !== 'DRAW' && !isDragging) {
         if (mode === 'SEQ') {
           console.log(`Clicked on C${id}`);

--- a/src/Canvas/DraggableItem.jsx
+++ b/src/Canvas/DraggableItem.jsx
@@ -12,7 +12,7 @@ import { ELEC_SIZE } from '../constants';
 
 function DraggableItem({ id, children }) {
   const {
-    mode, pinToElec, setPinToElec, elecToPin, setElecToPin, currPin,
+    mode, setCurrElec,
   } = useContext(GeneralContext);
 
   const context = useContext(CanvasContext);
@@ -41,24 +41,8 @@ function DraggableItem({ id, children }) {
 
   const handleMouseDown = useCallback((e) => {
     if (e.which === 1) {
-      if (mode === 'PIN' && currPin) {
-        const elec = `S${id}`;
-        if (Object.prototype.hasOwnProperty.call(pinToElec, currPin)) {
-          delete elecToPin[pinToElec[currPin]];
-        }
-        if (Object.prototype.hasOwnProperty.call(elecToPin, elec)) {
-          delete pinToElec[elecToPin[elec]];
-        }
-        setPinToElec((curr) => {
-          const newObj = { ...curr };
-          newObj[currPin] = elec;
-          return newObj;
-        });
-        setElecToPin((curr) => {
-          const newObj = { ...curr };
-          newObj[elec] = currPin;
-          return newObj;
-        });
+      if (mode === 'PIN') {
+        setCurrElec(`S${id}`);
       } else if (mode !== 'DRAW' && !isDragging) {
         if (isSelected) {
           setLocalMD(true);

--- a/src/Contexts/GeneralProvider.jsx
+++ b/src/Contexts/GeneralProvider.jsx
@@ -7,7 +7,7 @@ const GeneralContext = React.createContext();
 
 const GeneralProvider = ({ children }) => {
   const [mode, setMode] = useState('DRAW'); // either "PIN", "SEQ", or "CAN", or "DRAW"
-  const [currPin, setCurrPin] = useState(null);
+  const [currElec, setCurrElec] = useState(null);
   const [pinToElec, setPinToElec] = useState({});
   const [elecToPin, setElecToPin] = useState({});
 
@@ -59,8 +59,8 @@ const GeneralProvider = ({ children }) => {
         mode,
         setMode,
         bannerRef,
-        currPin,
-        setCurrPin,
+        currElec,
+        setCurrElec,
         pinToElec,
         setPinToElec,
         elecToPin,

--- a/src/Pins/PinsBottom.jsx
+++ b/src/Pins/PinsBottom.jsx
@@ -1,46 +1,49 @@
-import React, { useContext } from 'react';
-import { GeneralContext } from '../Contexts/GeneralProvider';
+import React from 'react';
 import range from './range';
+import useMap from './useMap';
 
 export default function PinsBottom() {
-  const { setCurrPin } = useContext(GeneralContext);
+  const [pin, setPin] = React.useState(null);
+  useMap(() => {
+    setPin(null);
+  }, pin);
 
   return (
     <>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
         {
-          range(169, 175).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(169, 175).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
         {
-          range(176, 182).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(176, 182).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
         {
-          range(183, 189).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(183, 189).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
         {
-          range(190, 196).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(190, 196).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
         {
-          range(168, 137).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
-        }
-      </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
-        {
-          range(41, 64).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
-        }
-        {
-          range(129, 136).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(168, 137).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
         {
-          range(40, 9).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(41, 64).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
+        }
+        {
+          range(129, 136).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
+        }
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
+        {
+          range(40, 9).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
       </div>
     </>

--- a/src/Pins/PinsTop.jsx
+++ b/src/Pins/PinsTop.jsx
@@ -1,43 +1,46 @@
-import React, { useContext } from 'react';
-import { GeneralContext } from '../Contexts/GeneralProvider';
+import React from 'react';
 import range from './range';
+import useMap from './useMap';
 
 export default function PinsTop() {
-  const { setCurrPin } = useContext(GeneralContext);
+  const [pin, setPin] = React.useState(null);
+  useMap(() => {
+    setPin(null);
+  }, pin);
 
   return (
     <>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
         {
-          range(97, 128).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(97, 128).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
         {
-          range(96, 65).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(96, 65).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
         {
-          range(225, 256).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(225, 256).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
       </div>
       <div style={{ display: 'flex', justifyContent: 'space-between', marginLeft: 49 }}>
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
         {
-          range(224, 218).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(224, 218).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
         {
-          range(217, 211).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(217, 211).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
         {
-          range(210, 204).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(210, 204).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
-        <button type="button" onClick={() => setCurrPin(null)}>REF</button>
+        <button type="button" onClick={() => setPin(null)}>REF</button>
         {
-          range(203, 197).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setCurrPin(e.target.innerText)}>{pinNum}</button>)
+          range(203, 197).map((pinNum, ind) => <button type="button" key={ind.id} onClick={(e) => setPin(e.target.innerText)}>{pinNum}</button>)
         }
       </div>
     </>

--- a/src/Pins/useMap.js
+++ b/src/Pins/useMap.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { GeneralContext } from '../Contexts/GeneralProvider';
+
+export default function useMap(callback, pin) {
+  const savedCallback = React.useRef();
+
+  // Remember the latest callback.
+  React.useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  const {
+    currElec, pinToElec, setPinToElec, elecToPin, setElecToPin,
+  } = React.useContext(GeneralContext);
+
+  React.useEffect(() => {
+    if (currElec && pin) {
+      if (Object.prototype.hasOwnProperty.call(pinToElec, pin)) {
+        delete elecToPin[pinToElec[pin]];
+      }
+      if (Object.prototype.hasOwnProperty.call(elecToPin, currElec)) {
+        delete pinToElec[elecToPin[currElec]];
+      }
+      setPinToElec((curr) => {
+        const newObj = { ...curr };
+        newObj[pin] = currElec;
+        return newObj;
+      });
+      setElecToPin((curr) => {
+        const newObj = { ...curr };
+        newObj[currElec] = pin;
+        return newObj;
+      });
+      savedCallback.current();
+    }
+  }, [pin]);
+}


### PR DESCRIPTION
Moved `setElectoPin` and `setPinToElec` funcs from DraggableItem and Draggable Comb to custom hook `useMap` to be called whenever the pins are clicked. So now the user must first click on the electrode then the pin to do the mapping.
This closes #112 