### PR TITLE
Add alert to indicate absense of service worker

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,7 +19,12 @@ ReactDOM.render(
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://cra.link/PWA
-serviceWorkerRegistration.register();
+if ('serviceWorker' in navigator) {
+  console.log('find service worker!');
+  serviceWorkerRegistration.register();
+} else {
+  window.alert('Service Worker not supported or using non https protocol.');
+}
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
This resolves #123 

When user uses a browser without service worker support, notify the user.