### PR TITLE
big canvas+get rid of fake centering

### DIFF
--- a/cypress/integration/canvas.test.js
+++ b/cypress/integration/canvas.test.js
@@ -44,7 +44,7 @@ describe('Canvas', () => {
     cy.get('[data-testid="CAN"]').click();
     cy.get('[data-testid="square"]').click();
 
-    cy.get('.greenArea').rightclick();
+    cy.get('.greenArea').rightclick({ force: true });
     cy.get('ul.menu > li:nth-child(4)').click({ force: true });
     cy.get('[data-testid="square"]').should('have.length', 0);
   });
@@ -55,7 +55,7 @@ describe('Canvas', () => {
 
     cy.get('[data-testid="CAN"]').click();
     cy.get('[data-testid="square"]').click({ multiple: true });
-    cy.get('.greenArea').rightclick();
+    cy.get('.greenArea').rightclick({ force: true });
     cy.get('ul.menu > li:nth-child(5)').click({ force: true });
     cy.get('[data-testid="square"]').should('have.length', 0);
     cy.get('[data-testid="combined"]').should('have.length', 1);
@@ -69,7 +69,7 @@ describe('Canvas', () => {
 
     cy.get('[data-testid="square"]').eq(0).click();
     cy.get('[data-testid="square"]').eq(1).click();
-    cy.get('.greenArea').rightclick();
+    cy.get('.greenArea').rightclick({ force: true });
     cy.get('ul.menu > li:nth-child(5)').click({ force: true });
 
     cy.get('[data-testid="square"]')
@@ -88,7 +88,7 @@ describe('Canvas', () => {
     cy.get('[data-testid="CAN"]').click();
 
     cy.get('[data-testid="square"]').click({ multiple: true });
-    cy.get('.greenArea').rightclick();
+    cy.get('.greenArea').rightclick({ force: true });
     cy.get('ul.menu > li:nth-child(5)').click({ force: true });
 
     cy.get('[data-testid="combined"]')
@@ -105,7 +105,7 @@ describe('Canvas', () => {
     cy.get('[data-testid="CAN"]').click();
     cy.get('[data-testid="square"]').eq(2).click();
     cy.get('[data-testid="square"]').eq(3).click();
-    cy.get('.greenArea').rightclick();
+    cy.get('.greenArea').rightclick({ force: true });
     cy.get('ul.menu > li:nth-child(5)').click({ force: true });
 
     cy.get('[data-testid="clear"]').click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,8 +26,10 @@
 
 Cypress.Commands.add('createSquare', (CELL) => {
   cy.get('.greenArea')
-    .trigger('mousedown', { which: 1, offsetX: CELL.x, offsetY: CELL.y })
-    .trigger('mousemove', { offsetX: CELL.x, offsetY: CELL.y })
+    .trigger('mousedown', {
+      which: 1, offsetX: CELL.x, offsetY: CELL.y, force: true,
+    })
+    .trigger('mousemove', { offsetX: CELL.x, offsetY: CELL.y, force: true })
     .trigger('mouseup', { force: true });
 });
 

--- a/src/Canvas/Canvas.css
+++ b/src/Canvas/Canvas.css
@@ -7,17 +7,14 @@
 
 .wrapper {
   overflow: scroll;
-  margin-left: 20vw;
-  /* margin-left: 20vw;
-  margin-top: 15vh;
-  margin-bottom: 20vh; */
+  margin-left: 49px;
 }
 
 .greenArea {
   background-color: #93D08C;
   width: 100%;
   height: 100%;
-  background-size: 40px 40px;
+  background-size: 35px 35px;
   background-image:
     linear-gradient(to right, grey 1px, transparent 1px),
     linear-gradient(to bottom, grey 1px, transparent 1px);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
-export const ELEC_SIZE = 40;
-export const CANVAS_WIDTH = 26; // electrodes
-export const CANVAS_HEIGHT = 12; // electrodes
+export const ELEC_SIZE = 35;
+export const CANVAS_WIDTH = 60; // electrodes
+export const CANVAS_HEIGHT = 30; // electrodes
 export const CANVAS_TRUE_WIDTH = CANVAS_WIDTH * ELEC_SIZE;
 export const CANVAS_TRUE_HEIGHT = CANVAS_HEIGHT * ELEC_SIZE;
 


### PR DESCRIPTION
Canvas now holds 60x30 (width x height) electrodes. Made grid squares just slightly smaller (35px x 35px) -- any more and I'd have to make the font smaller when showing the pin number in the electrodes. And since the new canvas size takes up more than the screen size now, removed that left-margin from before since don't need to "center" the canvas anymore.

Oh, and if you have electrodes cached in your browser, they won't fit the new grid so just clear your canvas.
This closes #115 