### PR TITLE
Fallback to traditional upload/download mechanism if file system API not available

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,8 @@
 
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
+  <input type="file" id="filePicker">
+  <a id="aDownloadFile" download></a>
   <div id="root"></div>
   <!--
       This HTML file is a template.

--- a/src/ControlPanel/ControlPanel.jsx
+++ b/src/ControlPanel/ControlPanel.jsx
@@ -13,7 +13,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Collapse from '@material-ui/core/Collapse';
 import {
-  Undo, Redo, Highlight, FileCopy, Create, Info, ViewWeek, Usb, Image, Menu,
+  Undo, Redo, Highlight, Create, Info, ViewWeek, Usb, Image, Menu,
   FormatListNumberedOutlined, GridOn,
 } from '@material-ui/icons';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -23,7 +23,7 @@ import { CanvasContext } from '../Contexts/CanvasProvider';
 import { GeneralContext } from '../Contexts/GeneralProvider';
 
 // import SaveButton from './SaveButton';
-// import UploadButton from './UploadButton';
+import UploadButton from './UploadButton';
 import DownloadButton from './DownloadButton';
 
 import USBPanel from './USBPanel';
@@ -136,9 +136,7 @@ export default function ControlPanel() {
               </ListItem>
             </Tooltip>
 
-            <ListItem button>
-              <FileCopy />
-            </ListItem>
+            <UploadButton />
             <ListItem button>
               <ViewWeek />
             </ListItem>

--- a/src/ControlPanel/DownloadButton.jsx
+++ b/src/ControlPanel/DownloadButton.jsx
@@ -12,13 +12,14 @@ export default function DownloadButton() {
   const { electrodes } = canvasContext.squares;
   const { allCombined } = canvasContext.combined;
   const { pinActuate } = actuationContext.actuation;
+  const aDownloadFile = document.getElementById('aDownloadFile');
   async function getNewFileHandle() {
     const options = {
       types: [
         {
-          description: 'Ewd Files',
+          description: 'Ewds Files',
           accept: {
-            '*/plain': ['.ewd'],
+            '*/plain': ['.ewds'],
           },
         },
       ],
@@ -37,11 +38,29 @@ export default function DownloadButton() {
     await writable.close();
   }
   async function handleDownload() {
-    const handle = await getNewFileHandle();
     const contents = genFileContents(electrodes, allCombined, pinActuate);
     const fileText = `${contents.squares.join('\n')}\n${contents.combs.join('\n')
     }\n#ENDOFELECTRODE#\n${contents.actuation.join('\n')}\n#ENDOFSEQUENCE#\n`;
-    writeFile(handle, fileText);
+    if ('showSaveFilePicker' in window) {
+      const handle = await getNewFileHandle();
+      writeFile(handle, fileText);
+    } else {
+      const fileName = 'untitled.ewds';
+      const opt = {
+        types: [
+          {
+            description: 'Ewds Files',
+            accept: {
+              '*/plain': ['.ewds'],
+            },
+          },
+        ],
+      };
+      const file = new File([fileText], '', opt);
+      aDownloadFile.href = window.URL.createObjectURL(file);
+      aDownloadFile.setAttribute('download', fileName);
+      aDownloadFile.click();
+    }
   }
 
   return (


### PR DESCRIPTION
**What**: Use traditional file upload/download mech for non-Chrome browser.
**Why**: Increase compatibility
**How**: put a file input and a link and hide them under the app.
**Testing**: Check it on Safari or IE or Firefox(maybe). Edge is built on top of Chrome so it might still use file system API.