### PR TITLE
erase pin mapping on delete or repeated click

### DIFF
--- a/src/Canvas/ContextMenu.jsx
+++ b/src/Canvas/ContextMenu.jsx
@@ -17,7 +17,9 @@ export default function ContextMenu() {
     setElectrodes, setSelected, setComboLayout, setCombSelected,
   } = canvasContext;
 
-  const { mode } = useContext(GeneralContext);
+  const {
+    setPinToElec, setElecToPin, pinToElec, elecToPin, mode,
+  } = useContext(GeneralContext);
 
   const [xPos, setXPos] = useState('0px');
   const [yPos, setYPos] = useState('0px');
@@ -102,6 +104,19 @@ export default function ContextMenu() {
   }
 
   function squaresDelete() {
+    // go through selected squares to erase any of their pin mappings
+    selected.forEach((index) => {
+      const square = `S${index}`;
+      const mappedPin = elecToPin[square];
+      if (mappedPin) { // mapping exists for this electrode so delete mapping
+        delete pinToElec[mappedPin];
+        delete elecToPin[square];
+      }
+    });
+
+    setPinToElec({ ...pinToElec });
+    setElecToPin({ ...elecToPin });
+
     const newPos = electrodes.initPositions.filter((val, ind) => !selected.includes(ind));
     const newDel = electrodes.deltas.filter((val, ind) => !selected.includes(ind));
     setSelected([]);
@@ -109,6 +124,18 @@ export default function ContextMenu() {
   }
 
   function combinedDelete() {
+    // go through selected combined elecs to erase any of their pin mappings
+    combSelected.forEach((index) => {
+      const combined = `C${index}`;
+      const mappedPin = elecToPin[combined];
+      if (mappedPin) { // mapping exists for this electrode so delete mapping
+        delete pinToElec[mappedPin];
+        delete elecToPin[combined];
+      }
+    });
+
+    setPinToElec({ ...pinToElec });
+    setElecToPin({ ...elecToPin });
     setComboLayout(allCombined.filter((combi) => !combSelected.includes(combi[2])));
     setCombSelected([]);
   }
@@ -229,8 +256,7 @@ export default function ContextMenu() {
       deltas: electrodes.deltas
         .concat(new Array(allCombined.length).fill(null).map(() => new Array(2).fill(0))),
     });
-    setComboLayout(allCombined.filter((combi) => !combSelected.includes(combi[2])));
-    setCombSelected([]);
+    combinedDelete();
   }
 
   const handleContextMenu = useCallback(

--- a/src/ControlPanel/ControlPanel.jsx
+++ b/src/ControlPanel/ControlPanel.jsx
@@ -101,7 +101,7 @@ const useStyles = makeStyles((theme) => ({
 export default function ControlPanel() {
   const canvasContext = useContext(CanvasContext);
   const actuationContext = useContext(ActuationContext);
-  const { setMode } = useContext(GeneralContext);
+  const { setMode, setCurrElec } = useContext(GeneralContext);
   const { setSelected, setCombSelected } = canvasContext;
   const { undo, redo } = actuationContext;
 
@@ -114,6 +114,7 @@ export default function ControlPanel() {
     setMode(newMode);
     setSelected([]);
     setCombSelected([]);
+    setCurrElec(null);
   }
 
   return (

--- a/src/ControlPanel/DeleteButton.jsx
+++ b/src/ControlPanel/DeleteButton.jsx
@@ -10,6 +10,7 @@ import Button from '@material-ui/core/Button';
 import { DialogContentText } from '@material-ui/core';
 import { CanvasContext } from '../Contexts/CanvasProvider';
 import { ActuationContext } from '../Contexts/ActuationProvider';
+import { GeneralContext } from '../Contexts/GeneralProvider';
 
 export default function DeleteButton() {
   const context = useContext(CanvasContext);
@@ -18,6 +19,8 @@ export default function DeleteButton() {
     setSelected, setElectrodes, setCombSelected, setComboLayout,
   } = context;
   const { clearAll } = actuation;
+
+  const { setPinToElec, setElecToPin } = useContext(GeneralContext);
   const [open, setOpen] = useState(false);
 
   function handleDelete() {
@@ -29,6 +32,10 @@ export default function DeleteButton() {
       deltas: [],
     });
     setComboLayout([]);
+
+    setPinToElec({});
+    setElecToPin({});
+
     clearAll();
     setOpen(false);
   }

--- a/src/Pins/useMap.js
+++ b/src/Pins/useMap.js
@@ -16,11 +16,34 @@ export default function useMap(callback, pin) {
   React.useEffect(() => {
     if (currElec && pin) {
       if (Object.prototype.hasOwnProperty.call(pinToElec, pin)) {
+        if (pinToElec[pin] === currElec) {
+          // when user wants to erase one pin <-> elec mapping
+          // e.g. pin 100 <-> electrode S3
+          // then hit pin 100 again while select electrode S3
+          // then set the absolute state and return immediately
+          setPinToElec((curr) => {
+            const newObj = { ...curr };
+            delete newObj[pin];
+            return newObj;
+          });
+          setElecToPin((curr) => {
+            const newObj = { ...curr };
+            delete newObj[currElec];
+            return newObj;
+          });
+          savedCallback.current();
+          return;
+        }
+        // otherwise just delete local copy of state
+        // going in these if statements means user wants to,
+        // for instance, assign pin to ANOTHER electrode
+        // than what that pin is currently assigned to
         delete elecToPin[pinToElec[pin]];
       }
       if (Object.prototype.hasOwnProperty.call(elecToPin, currElec)) {
         delete pinToElec[elecToPin[currElec]];
       }
+
       setPinToElec((curr) => {
         const newObj = { ...curr };
         newObj[pin] = currElec;


### PR DESCRIPTION
# Summary
Enable user to delete a pin<->electrode mapping on: 
1. click again on pin while selecting electrode it's already mapped to
    - e.g. if pin 100 <-> electrode S3
    - then click on pin 100 again while having selected electrode S3
    - thereby delete pin 100 <-> electrode S3 mapping
2. clear canvas
3. delete selected electrodes via context menu
    - deletion happens on commands:
      -  "Separate" (delete selected combined)
      - "Combine" (delete selected squares)
      - "Cut" (delete all selected electrodes)
      - and of course "Delete"
 
## Note
- realize there's a lil bug where if you click on pin first and THEN electrode when you first enter PIN mode, the mapping doesn't happen when you next click on a pin -- though when you click on another pin it works fine starting from there
  - to be resolved in another PR

This closes #114. 