### PR TITLE
fix pin canvas height + init zoom

### DIFF
--- a/src/Canvas/Canvas.css
+++ b/src/Canvas/Canvas.css
@@ -6,7 +6,6 @@
 }
 
 .wrapper {
-  overflow: visible;
   margin-left: 49px;
 }
 

--- a/src/Canvas/Canvas.jsx
+++ b/src/Canvas/Canvas.jsx
@@ -196,10 +196,19 @@ export default function Canvas() {
   /* ########################### COMBINE STUFF END ########################### */
 
   return (
-    <div className="wrapper" style={{ height: CANVAS_REAL_HEIGHT, width: CANVAS_REAL_WIDTH }}>
+    <div
+      className="wrapper"
+      style={{
+        height: CANVAS_REAL_HEIGHT,
+        width: CANVAS_REAL_WIDTH,
+        overflow: mode === 'PIN' ? 'hidden' : 'visible',
+      }}
+    >
       <TransformWrapper
+        initialScale={mode === 'PIN' ? 0.51 : 1}
+        minScale={0.51}
         limitToBounds={false}
-        panning={{ disabled: mode !== 'PAN' }}
+        panning={{ disabled: mode !== 'PAN' && mode !== 'PIN' }}
         onPanningStop={(ref) => {
           let newX = ref.state.positionX;
           let newY = ref.state.positionY;
@@ -226,7 +235,7 @@ export default function Canvas() {
                   y={startPos[1]}
                   width={ELEC_SIZE - 5}
                   height={ELEC_SIZE - 5}
-                  className={`electrode 
+                  className={`electrode
                                 ${mode === 'SEQ' && pinActuate.has(currentStep)
                                 && Object.prototype.hasOwnProperty.call(elecToPin, `S${ind}`) && pinActuate.get(currentStep).content.has(elecToPin[`S${ind}`]) ? 'toSeq' : ''}
                                 ${mode === 'CAN' && selected.includes(ind) ? 'selected' : ''}


### PR DESCRIPTION
- Show the whole canvas with initial scale factor of 1 and starting position at the top left of the white space when in any mode other than PIN
- Otherwise show a cropped portion of the canvas with initial scale factor of 0.51 and starting position at the top left of the empty part of the chassis
  - 0.51 because it almost shows all of the canvas while showing the canvas grid

This closes #138 