### PR TITLE
Separate pin tests

### DIFF
--- a/cypress/integration/canvas.test.js
+++ b/cypress/integration/canvas.test.js
@@ -182,22 +182,7 @@ describe('Canvas', () => {
   });
 
   it('Drag with middle mouse button to pan', () => {
-    cy.get('.greenArea')
-      .trigger('mousedown', CELL2.x, CELL2.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mousemove', CELL2.x, CELL2.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mousemove', CELL4.x, CELL4.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mouseup', CELL4.x, CELL4.y, {
-        force: true,
-      });
+    cy.drag(CELL2, CELL4, '.greenArea', 2);
 
     cy.get('.greenArea').parent()
       .should(

--- a/cypress/integration/pin.test.js
+++ b/cypress/integration/pin.test.js
@@ -193,22 +193,8 @@ describe('Pin', () => {
 
     const from = { x: 150, y: 150 };
     const to = { x: 200, y: 200 };
-    cy.get('#chassis')
-      .trigger('mousedown', from.x, from.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mousemove', from.x, from.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mousemove', to.x, to.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mouseup', to.x, to.y, {
-        force: true,
-      });
+
+    cy.drag(from, to, '#chassis', 2);
 
     cy.get('#chassis').parent()
       .should(
@@ -221,22 +207,7 @@ describe('Pin', () => {
   it('Panning on green without panning mode', () => {
     cy.get('[data-testid="PIN"]').click();
 
-    cy.get('.greenArea')
-      .trigger('mousedown', CELL1.x, CELL1.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mousemove', CELL1.x, CELL1.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mousemove', CELL2.x, CELL2.y, {
-        which: 2,
-        force: true,
-      })
-      .trigger('mouseup', CELL2.x, CELL2.y, {
-        force: true,
-      });
+    cy.drag(CELL1, CELL2, '.greenArea', 2);
 
     cy.get('.greenArea').parent()
       .should(


### PR DESCRIPTION
Fixes #192 
Decided to put any test that primarily tests something on the pin page in `pin.test.js`

And in the second commit, replaced all manual copy pastes with the custom cypress drag cmd I'd created after the fact
e.g.
```
    cy.get('#chassis')
      .trigger('mousedown', from.x, from.y, {
        which: 2,
        force: true,
      })
      .trigger('mousemove', from.x, from.y, {
        which: 2,
        force: true,
      })
      .trigger('mousemove', to.x, to.y, {
        which: 2,
        force: true,
      })
      .trigger('mouseup', to.x, to.y, {
        force: true,
      });
```
to `cy.drag(from, to, '#chassis', 2)`