### PR TITLE
Use Array.every() instead of Array.forEach()

### DIFF
--- a/src/Canvas/useSelected.js
+++ b/src/Canvas/useSelected.js
@@ -159,10 +159,9 @@ export default function useSelected(callback, savingChanges) {
 
       // new bool ensures that we only move electrodes in comb if
       // we know for sure the comb does not move off the screen.
-      let allOnCanvas = true;
       if (combSelected.length > 0) {
         const newCombines = [...allCombined];
-        newCombines.forEach((comb) => {
+        const allOnCanvas = newCombines.every((comb, ind) => {
           if (setOfCombSelected.has(`${comb[2]}`)) { // this elec was selected
             // so record its new position
             const newX = parseInt(comb[0], 10) + delta.x;
@@ -171,27 +170,17 @@ export default function useSelected(callback, savingChanges) {
             if (newX < 0 || newX >= CANVAS_TRUE_WIDTH || newY < 0 || newY >= CANVAS_TRUE_HEIGHT) {
               bannerRef.current.getAlert('error', 'Combined electrode going off canvas!');
               reset();
-              allOnCanvas = false;
-              // might want to consider changing this loop to end when this block ends
-              // for efficiency.
+              return false;
             }
+            newCombines[ind][0] = newX;
+            newCombines[ind][1] = newY;
           }
+          return true;
         });
-        // we run the forEach loop twice. not really ideal but fixes the problem.
         if (allOnCanvas) {
-          newCombines.forEach((comb, ind) => {
-            if (setOfCombSelected.has(`${comb[2]}`)) { // this elec was selected
-              // so record its new position
-              const newX = parseInt(comb[0], 10) + delta.x;
-              const newY = parseInt(comb[1], 10) + delta.y;
-              newCombines[ind][0] = newX;
-              newCombines[ind][1] = newY;
-            }
-          });
-
           setComboLayout(newCombines);
-          setCombSelected([]);
         }
+        setCombSelected([]);
       }
 
       if (elecSelected.length > 0) {


### PR DESCRIPTION
`forEach` cannot early terminate, so instead use `every` so that we can
avoid wasting cycles if we detect the electrode going off canvas early
on in the array. We can also avoid doing a second loop by only setting
the combo layout if the flag `allOnCanvas` is set.