### PR TITLE
Fix incorrect selected electrode when moving cut&pasted electrode

### DIFF
--- a/src/Canvas/Canvas.jsx
+++ b/src/Canvas/Canvas.jsx
@@ -898,7 +898,7 @@ export default function Canvas() {
                                     ${mode === 'SEQ' && pinActuate.has(currentStep)
                                     && Object.prototype.hasOwnProperty.call(elecToPin, `C${comb[0]}`)
                                     && pinActuate.get(currentStep).content.has(elecToPin[`C${comb[0]}`]) ? 'toSeq' : ''}
-                                    ${mode === 'CAN' && combSelected.includes(`${ind}`) ? 'selected' : ''}
+                                    ${mode === 'CAN' && combSelected.includes(`${comb[0]}`) ? 'selected' : ''}
                                     ${mode === 'PIN' && currElec === `C${comb[0]}` ? 'toPin' : ''}`}
                       data-testid="combined"
                     />


### PR DESCRIPTION
Fixed the variable which highlights the electrode that is selected after cutting and pasting combined electrodes.