### PR TITLE
Update workflow file to guarantee correct Node version

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v3.6.0
+        with:
+          node-version: 14.18.1
+
       - name: cypress
         uses: cypress-io/github-action@v2
         with:


### PR DESCRIPTION
Editted the Cypress workflow file so that it always uses Node 14.18.1 to prevent any issues that arise from incompatible versions.