### PR TITLE
Can deselect electrodes by clicking anywhere on the grid

### DIFF
--- a/src/Canvas/Canvas.jsx
+++ b/src/Canvas/Canvas.jsx
@@ -55,7 +55,7 @@ export default function Canvas() {
   const startShift = useCallback((event) => {
     if (event.keyCode === 16) {
       setShiftDown(true);
-      // If some electrodes are selected, turn off default movement so user can select the electrodes
+      // If some electrodes are selected, turn off default movement so user can select again
       if ((selected || combSelected) && mode === 'CAN') {
         setMoving(false);
       }


### PR DESCRIPTION
Resolves #269. Because of default move on select, we weren't able to deselect our electrodes without the unselect functionality. This has been fixed now so that users can deselect the current selection by clicking anywhere on the screen. If an electrode is clicked on, the current selection is discarded and the electrode becomes the new selection.