### PR TITLE
Fix For Unexpected Scrolling While In Sequencing Drawer

### DIFF
--- a/src/Canvas/Canvas.jsx
+++ b/src/Canvas/Canvas.jsx
@@ -882,8 +882,8 @@ export default function Canvas() {
     <div
       className="wrapper"
       style={{
-        height: mode === 'SEQ' ? '600px': CANVAS_REAL_HEIGHT,
-        width: mode === 'SEQ' ? '1500px': CANVAS_REAL_WIDTH,
+        height: mode === 'SEQ' ? '600px' : CANVAS_REAL_HEIGHT,
+        width: mode === 'SEQ' ? '1500px' : CANVAS_REAL_WIDTH,
         overflow: mode === 'SEQ' || mode === 'PIN' ? 'hidden' : 'visible',
       }}
     >


### PR DESCRIPTION
Changed a few lines of code in the Canvas.jsx file that makes the canvas stationary while in sequencing mode and resizes the canvas dimensions. If there is other unexpected scrolling in the drawer due to the text-overflow, that should be fixed once my previous pull request is layered on top of this one.